### PR TITLE
Fixed compilation error - String literal should use double quotes

### DIFF
--- a/src/org/launchcode/java/demos/java4python/ElseIf.java
+++ b/src/org/launchcode/java/demos/java4python/ElseIf.java
@@ -7,7 +7,7 @@ import java.util.Scanner;
 public class ElseIf {
     public static void main(String args[]) {
         Scanner in = new Scanner(System.in);
-        System.out.println('enter a grade');
+        System.out.println("enter a grade");
         int grade = in.nextInt();
         
         if (grade < 60) {


### PR DESCRIPTION
When attempting to compile "Hello World", the modified line caused a compilation error due to use of single quotes for a string literal. 

Per https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html:
" Always use 'single quotes' for char literals and "double quotes" for String literals."